### PR TITLE
Update Action.php

### DIFF
--- a/src/Nova/Filters/Action.php
+++ b/src/Nova/Filters/Action.php
@@ -17,7 +17,7 @@ class Action extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
-        return $query->where('name', $value);
+        return $value ? $query->where('name', $value) : $query;
     }
 
     /**


### PR DESCRIPTION
There is no way to show not filtered entities with the current implementation.

Nova adds an empty filter `-` and Bouncer tries to filter abilities by empty value
