### PR TITLE
Added Bouncers new release version - silber/bouncer v1.0.0-rc.7 - to support Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1.3",
         "laravel/nova": "*",
-        "silber/bouncer": "v1.0.0-rc.4|v1.0.0-rc.5|v1.0.0-rc.6"
+        "silber/bouncer": "v1.0.0-rc.4|v1.0.0-rc.5|v1.0.0-rc.6|v1.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bouncer just released **v1.0.0-rc.7** which allows for Laravel 7 support.

This PR adds support for the new release.